### PR TITLE
Use == instead of ===

### DIFF
--- a/lib/event_logger.ex
+++ b/lib/event_logger.ex
@@ -7,7 +7,7 @@ defmodule EventLogger do
     Logger.log(level, format(level, data))
   end
 
-  defp format(level, data) when data === nil or data === "" do
+  defp format(level, data) when data == nil or data == "" do
     format(level, "Event Logger received log level, but no error message was provided")
   end
 


### PR DESCRIPTION
The === comparison should be used when comparing ints and floats as it
gives a stricter comparison of those data types.
More can be read about that here:
https://elixir-lang.org/getting-started/basic-operators.html

`The difference between == and === is that the latter is more strict
when comparing integers and floats`