### PR TITLE
Time per environment and colour breaking tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,7 @@ use Mix.Config
 #
 #     import_config "#{Mix.env()}.exs"
 
-config :logger, :console, format: "$message\n"
+config :logger, :console, format: "$message\n", colors: [enabled: false]
 
 config :event_logger, :environment, Mix.env()
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,3 +30,7 @@ use Mix.Config
 #     import_config "#{Mix.env()}.exs"
 
 config :logger, :console, format: "$message\n"
+
+config :event_logger, :environment, Mix.env()
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :event_logger, time_api: EventLogger.Time.DateTime

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :event_logger, time_api: EventLogger.Time.DateTime

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :event_logger, time_api: EventLogger.Time.MockTime

--- a/lib/event_logger.ex
+++ b/lib/event_logger.ex
@@ -1,7 +1,7 @@
 defmodule EventLogger do
   import Logger, only: [log: 2]
 
-  @time EventLogger.Time.MockTime
+  @time Application.get_env(:event_logger, :time_api)
 
   def log(level, data) when level in [:error, :warn, :info] do
     Logger.log(level, format(level, data))
@@ -12,7 +12,8 @@ defmodule EventLogger do
   end
 
   defp format(level, data) when is_map(data) do
-    Map.merge(data, %{datetime: time(), level: to_string(level)})
+    data
+    |> Map.merge(%{datetime: time(), level: to_string(level)})
     |> Poison.encode!()
   end
 


### PR DESCRIPTION
This is so the tests will use TimeMock but the production code will
receive the output from DateTime.utc_now from the EventLogger.Time
method.