### PR TITLE
Documentation updates for file backend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 EventLogger is an Elixir log wrapper that allows you to pass Maps into the built in Logger function, returning them in a JSON format and outputting to a file in Production mode.
 Providing you with the ability to write more descriptive log messages and send logs to services expecting logs in the json/map format.
+The library isnt limited to maps, it can also take in strings and create JSON formatted log messages.
 
 ## Installation
 
@@ -30,7 +31,7 @@ Once the packages has been installed into your package we recommend usage as so:
 ```
 
 Providing you with output in this format:
- ```
+ ```elixir
   {"message":"Error Logged","level":"error","datetime":"2019-03-06T12:18:24.179731Z"}
   :ok
 ```
@@ -51,3 +52,33 @@ It can also be nicely used in conjuction with libraries such as [HTTPoison](http
   end
 ```
 
+## Configuration
+
+The default configuration for this will simply log to the console, if you would like to configure it you can simply edit your `config.exs` file.
+It is worth noting that you must keep the format as `format: "$message\n"` with whichever logging backend you choose to use otherwise you will get duplication of information.
+
+For example if you would like to Log to a file the following configuration would be recommended:
+
+- First edit your `mix.exs` and add the LoggerFileBackend
+
+```elixir
+  defp deps do
+    [
+      {:logger_file_backend, "~> 0.0.10"}
+    ]
+  end
+```
+
+- Run mix deps.get
+
+- Edit your `config.exs`
+
+```elixir
+config :logger,
+  backends: [{LoggerFileBackend, :file}]
+
+config :logger, :file,
+  path: "/var/log/my_app/error.log",
+  format: "$message\n",
+  level: :debug
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 EventLogger is an Elixir log wrapper that allows you to pass Maps into the built in Logger function, returning them in a JSON format and outputting to a file in Production mode.
 Providing you with the ability to write more descriptive log messages and send logs to services expecting logs in the json/map format.
-The library isnt limited to maps, it can also take in strings and create JSON formatted log messages.
+The library is not limited to maps, it can also take in strings and create JSON formatted log messages.
 
 ## Installation
 
@@ -22,7 +22,7 @@ and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/event_logger](https://hexdocs.pm/event_logger).
 
 ## Usage
-Once the packages has been installed into your package we recommend usage as so:
+Once the package has been installed into your project, the following usage is recommended:
 
 ```elixir
   def foo do
@@ -57,7 +57,7 @@ It can also be nicely used in conjuction with libraries such as [HTTPoison](http
 The default configuration for this will simply log to the console, if you would like to configure it you can simply edit your `config.exs` file.
 It is worth noting that you must keep the format as `format: "$message\n"` with whichever logging backend you choose to use otherwise you will get duplication of information.
 
-For example if you would like to Log to a file the following configuration would be recommended:
+If for example you would like to Log to a file the following configuration would be recommended:
 
 - First edit your `mix.exs` and add the LoggerFileBackend
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,6 @@ use Mix.Config
 # You can also configure a third-party app:
 #
 #     config :logger, level: :info
-#
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
@@ -29,8 +28,10 @@ use Mix.Config
 #
 #     import_config "#{Mix.env()}.exs"
 
-config :logger, :console, format: "$message\n", colors: [enabled: false]
-
 config :event_logger, :environment, Mix.env()
+
+config :event_logger, time_api: EventLogger.Time.DateTime
+
+config :logger, :console, format: "$message\n"
 
 import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :event_logger, time_api: EventLogger.Time.DateTime

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :event_logger, time_api: EventLogger.Time.DateTime

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,7 @@
 use Mix.Config
 
 config :event_logger, time_api: EventLogger.Time.MockTime
+
+config :logger, :console,
+  format: "$message\n",
+  colors: [enabled: false]

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,11 @@ defmodule EventLogger.MixProject do
       app: :event_logger,
       version: "0.1.0",
       elixir: "~> 1.8",
+      build_embedded: Mix.env == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      description: description,
+      package: package
     ]
   end
 
@@ -23,5 +26,21 @@ defmodule EventLogger.MixProject do
     [
       {:poison, "~> 3.1"}
     ]
+  end
+
+  defp description do
+    """
+      A logging library that will ouput to JSON given a log level and a message to log.
+    """
+  end
+
+  defp package do
+    [
+     files: ["lib", "mix.exs", "README.md"],
+     maintainers: ["bbc", "JoeARO", "woodyblah", "james-bowers", "ettomatic", "samfrench", "alexmuller"],
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/JoeARO/event_logger",
+              "Docs" => "https://hexdocs.pm/event_logger/"}
+     ]
   end
 end


### PR DESCRIPTION
This contains changes to the documentation giving a configuration
guide specifically how to use a custom backend for logging to a file.

Due to the inheritance through config files I have also changed the
top level `config.exs` to contain the non test related time_api variable,
however I an empty `dev.exs` is required, otherwise `iex -S mix` throws an error.