### PR TITLE
Renamed the project to be less generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-event_logger-*.tar
+stump-*.tar
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-# EventLogger
+# Stump
 
-EventLogger is an Elixir log wrapper that allows you to pass Maps into the built in Logger function, returning them in a JSON format and outputting to a file in Production mode.
+Stump is an Elixir log wrapper that allows you to pass Maps into the built in Logger function, returning them in a JSON format and outputting to a file in Production mode.
 Providing you with the ability to write more descriptive log messages and send logs to services expecting logs in the json/map format.
 The library is not limited to maps, it can also take in strings and create JSON formatted log messages.
 
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `event_logger` to your list of dependencies in `mix.exs`:
+by adding `stump` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:event_logger, "~> 0.1.0"}
+    {:stump, "~> 0.1.0"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/event_logger](https://hexdocs.pm/event_logger).
+be found at [https://hexdocs.pm/stump](https://hexdocs.pm/stump).
 
 ## Usage
 Once the package has been installed into your project, the following usage is recommended:
 
 ```elixir
   def foo do
-    EventLogger.log(:error, %{message: "Error Logged"})
+    Stump.log(:error, %{message: "Error Logged"})
   end
 ```
 
@@ -47,7 +47,7 @@ It can also be nicely used in conjuction with libraries such as [HTTPoison](http
 
 ```elixir
   def process(_, {:error, %HTTPoison.Error{reason: reason}}) do
-    EventLogger.log(:error, %{message: "Failed to process HTTP request, reason: #{reason}", event: "HTTPoison.Error"})
+    Stump.log(:error, %{message: "Failed to process HTTP request, reason: #{reason}", event: "HTTPoison.Error"})
     {:error, reason}
   end
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,11 +10,11 @@ use Mix.Config
 
 # You can configure your application as:
 #
-#     config :event_logger, key: :value
+#     config :stump, key: :value
 #
 # and access this configuration in your application as:
 #
-#     Application.get_env(:event_logger, :key)
+#     Application.get_env(:stump, :key)
 #
 # You can also configure a third-party app:
 #
@@ -28,9 +28,9 @@ use Mix.Config
 #
 #     import_config "#{Mix.env()}.exs"
 
-config :event_logger, :environment, Mix.env()
+config :stump, :environment, Mix.env()
 
-config :event_logger, time_api: EventLogger.Time.DateTime
+config :stump, time_api: Stump.Time.DateTime
 
 config :logger, :console, format: "$message\n"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :event_logger, time_api: EventLogger.Time.MockTime
+config :stump, time_api: Stump.Time.MockTime
 
 config :logger, :console,
   format: "$message\n",

--- a/lib/event_logger.ex
+++ b/lib/event_logger.ex
@@ -1,7 +1,7 @@
-defmodule EventLogger do
+defmodule Stump do
   import Logger, only: [log: 2]
 
-  @time Application.get_env(:event_logger, :time_api)
+  @time Application.get_env(:stump, :time_api)
 
   def log(level, data) when level in [:error, :warn, :info] do
     Logger.log(level, format(level, data))

--- a/lib/event_logger/time.ex
+++ b/lib/event_logger/time.ex
@@ -1,3 +1,3 @@
-defmodule EventLogger.Time do
+defmodule Stump.Time do
   @callback utc_now() :: DateTime
 end

--- a/lib/event_logger/time/date_time.ex
+++ b/lib/event_logger/time/date_time.ex
@@ -1,5 +1,5 @@
-defmodule EventLogger.Time.DateTime do
-  @behaviour EventLogger.Time
+defmodule Stump.Time.DateTime do
+  @behaviour Stump.Time
   import DateTime, only: [utc_now: 0]
 
   def utc_now() do

--- a/lib/event_logger/time/mock_time.ex
+++ b/lib/event_logger/time/mock_time.ex
@@ -1,5 +1,5 @@
-defmodule EventLogger.Time.MockTime do
-  @behaviour EventLogger.Time
+defmodule Stump.Time.MockTime do
+  @behaviour Stump.Time
 
   def utc_now() do
     DateTime.from_unix!(01551398400) # It's always 1st March 2019

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule EventLogger.MixProject do
+defmodule Stump.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :event_logger,
+      app: :stump,
       version: "0.1.0",
       elixir: "~> 1.8",
       build_embedded: Mix.env == :prod,
@@ -39,8 +39,8 @@ defmodule EventLogger.MixProject do
      files: ["lib", "mix.exs", "README.md"],
      maintainers: ["bbc", "JoeARO", "woodyblah", "james-bowers", "ettomatic", "samfrench", "alexmuller"],
      licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/JoeARO/event_logger",
-              "Docs" => "https://hexdocs.pm/event_logger/"}
+     links: %{"GitHub" => "https://github.com/JoeARO/stump",
+              "Docs" => "https://hexdocs.pm/stump/"}
      ]
   end
 end

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -1,29 +1,29 @@
-defmodule EventLoggerTest do
+defmodule StumpTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
   require Logger
 
   test "time" do
-    assert EventLogger.time == EventLogger.Time.MockTime.utc_now()
+    assert Stump.time == Stump.Time.MockTime.utc_now()
   end
 
   test "when log level is valid but the message provided is '', it logs an error" do
-    assert capture_log(fn ->EventLogger.log(:error, "") end) == "{\"message\":\"Event Logger received log level, but no error message was provided\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:error, "") end) == "{\"message\":\"Event Logger received log level, but no error message was provided\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
   end
 
   test "when log level is valid but the message provided is nil, it logs an error" do
-    assert capture_log(fn ->EventLogger.log(:error, nil) end) == "{\"message\":\"Event Logger received log level, but no error message was provided\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"message\":\"Event Logger received log level, but no error message was provided\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
   end
 
   test "when log level is :info and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->EventLogger.log(:info, "Here is some info") end) == "{\"message\":\"Here is some info\",\"level\":\"info\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"message\":\"Here is some info\",\"level\":\"info\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
   end
 
   test "when log level is :warn and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->EventLogger.log(:warn, "This is a warning") end) == "{\"message\":\"This is a warning\",\"level\":\"warn\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:warn, "This is a warning") end) == "{\"message\":\"This is a warning\",\"level\":\"warn\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
   end
 
   test "when log level is :error and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->EventLogger.log(:error, "There was an error") end) == "{\"message\":\"There was an error\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:error, "There was an error") end) == "{\"message\":\"There was an error\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
   end
 end


### PR DESCRIPTION
This is because the Logger seemed rather generic when in fact this does a few things the basic logger doesn't do.
Namely the ability to pass a map into the Logger and output JSON logs.