### PR TITLE
Default time api

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,4 +32,6 @@ config :stump, :environment, Mix.env()
 
 config :logger, :console, format: "$message\n"
 
-import_config "#{Mix.env}.exs"
+if Mix.env == :test do
+  import_config "test.exs"
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,0 @@
-use Mix.Config
-
-config :stump, time_api: Stump.Time.DateTime
-
-config :logger, :console, format: "$message\n"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,0 @@
-use Mix.Config
-
-config :stump, time_api: Stump.Time.DateTime
-
-config :logger, :console, format: "$message\n"

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -24,8 +24,6 @@ defmodule Stump do
   """
   import Logger, only: [log: 2]
 
-  @time Application.get_env(:stump, :time_api)
-
   def log(level, data) when level in [:error, :warn, :info] do
     Logger.log(level, format(level, data))
   end
@@ -47,6 +45,6 @@ defmodule Stump do
 
   @doc false
   def time() do
-    @time.utc_now()
+    Application.get_env(:stump, :time_api).utc_now()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,9 @@ defmodule Stump.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Stump.Application, [env: Mix.env()]},
+      env: [time_api: Stump.Time.DateTime]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,6 @@ defmodule Stump.MixProject do
   def application do
     [
       extra_applications: [:logger],
-      mod: {Stump.Application, [env: Mix.env()]},
       env: [time_api: Stump.Time.DateTime]
     ]
   end


### PR DESCRIPTION
Set a default for the time_api variable, which helps us to avoid users of the package from having to duplicate configuration already set in `Stump`.